### PR TITLE
Switch to Travis CI VM infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: R
-sudo: false
 cache: packages
 
 language: r


### PR DESCRIPTION
'sudo' is deprecated: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration